### PR TITLE
Explain how to select profile for serverless

### DIFF
--- a/README.md
+++ b/README.md
@@ -1371,8 +1371,16 @@ nextamplified:
 To deploy, run the following command from your terminal:
 
 ```
+# Mac & Linux
+export AWS_PROFILE="amplify-cli-user"
+
+# Windows
+set AWS_PROFILE=amplify-cli-user
+
 npx serverless
 ```
+
+> Make sure that `amplify-cli-user` matches the profile name that you used when you ran `amplify configure` as part of [Installing the CLI](#installing-the-cli). Unfortunatelly, the component doesn't have an input to set the AWS Profile nor picks up on [`--aws-profile`](https://www.serverless.com/framework/docs/providers/aws/guide/credentials/), so we need to use an environment variable. If you get `AccessDenied`, check if `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` aren't set as well, as they [override](https://github.com/serverless-nextjs/serverless-next.js/issues/968) the profile. In that case, temporarily set those to the profile's values found in `~/.aws/credentials`.
 
 ## Removing Services
 


### PR DESCRIPTION
I ran into `Access Denied` running `npx serverless`:

<details>

```
% npx serverless


  error:
  AccessDenied: Access Denied
    at Request.extractError (/Users/fokkezb/.serverless/components/registry/npm/@sls-next/serverless-component@1.18.0/node_modules/aws-sdk/lib/services/s3.js:718:35)
    at Request.callListeners (/Users/fokkezb/.serverless/components/registry/npm/@sls-next/serverless-component@1.18.0/node_modules/aws-sdk/lib/sequential_executor.js:106:20)
    at Request.emit (/Users/fokkezb/.serverless/components/registry/npm/@sls-next/serverless-component@1.18.0/node_modules/aws-sdk/lib/sequential_executor.js:78:10)
    at Request.emit (/Users/fokkezb/.serverless/components/registry/npm/@sls-next/serverless-component@1.18.0/node_modules/aws-sdk/lib/request.js:688:14)
    at Request.transition (/Users/fokkezb/.serverless/components/registry/npm/@sls-next/serverless-component@1.18.0/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/Users/fokkezb/.serverless/components/registry/npm/@sls-next/serverless-component@1.18.0/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /Users/fokkezb/.serverless/components/registry/npm/@sls-next/serverless-component@1.18.0/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/Users/fokkezb/.serverless/components/registry/npm/@sls-next/serverless-component@1.18.0/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/Users/fokkezb/.serverless/components/registry/npm/@sls-next/serverless-component@1.18.0/node_modules/aws-sdk/lib/request.js:690:12)
    at Request.callListeners (/Users/fokkezb/.serverless/components/registry/npm/@sls-next/serverless-component@1.18.0/node_modules/aws-sdk/lib/sequential_executor.js:116:18) {
  code: 'AccessDenied',
  region: null,
  time: 2021-04-07T08:04:39.056Z,
  requestId: 'KGT4WPVPHR7NBP78',
  extendedRequestId: '074/Dl/2DxI8uXXbx13LNOCFtIJVKwQWRYU90Fut5SsCDHGFXRji/NQHlZ2crXFEFxbIHzgqLqE=',
  cfId: undefined,
  statusCode: 403,
  retryable: false,
  retryDelay: 44.634347076168844
}
```

</details>

I found that it used my default profile instead of the one created in the "Installing the CLI" section. Based on https://www.serverless.com/framework/docs/providers/aws/guide/credentials/ I found out how to select the workshop profile. This PR updates the README to explain how to do this.

Notice that I also touch on https://github.com/serverless-nextjs/serverless-next.js/issues/968 which users might run into.