### PR TITLE
Keep revalidate around when making changes to posts/[id].js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1181,7 +1181,11 @@ export async function getStaticProps ({ params }) {
   return {
     props: {
       post: postData.data.getPost
-    }
+    },
+    // Next.js will attempt to re-generate the page:
+    // - When a request comes in
+    // - At most once every second
+    revalidate: 1 // adds Incremental Static Generation, sets time in seconds
   }
 }
 ```

--- a/amplify-next/pages/posts/[id].js
+++ b/amplify-next/pages/posts/[id].js
@@ -53,6 +53,10 @@ export async function getStaticProps ({ params }) {
   return {
     props: {
       post: postData.data.getPost
-    }
+    },
+    // Next.js will attempt to re-generate the page:
+    // - When a request comes in
+    // - At most once every second
+    revalidate: 1 // adds Incremental Static Generation, sets time in seconds
   }
 }


### PR DESCRIPTION
I noticed that in the step for "Rendering the cover image in the detail view", the revalidate property added in "Enabling Incremental Static Generation" got removed. I _think_ this was unintentional, so I've added it back.