### PR TITLE
Remove storage instead of auth to avoid error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1379,7 +1379,7 @@ npx serverless
 If at any time, or at the end of this workshop, you would like to delete a service from your project & your account, you can do this by running the `amplify remove` command:
 
 ```sh
-$ amplify remove auth
+$ amplify remove storage
 
 $ amplify push
 ```


### PR DESCRIPTION
The README uses auth as example for `amplify remove` but as this doesn't remove the dependencies on it first, this produces an error on push:

<details>

```
% amplify push       
✔ Successfully pulled backend environment dev from the cloud.

Current Environment: dev

| Category | Resource name       | Operation | Provider plugin   |
| -------- | ------------------- | --------- | ----------------- |
| Auth     | amplifynexta0fb67a2 | Delete    | awscloudformation |
| Api      | NextBlog            | No Change | awscloudformation |
| Storage  | projectimages       | No Change | awscloudformation |
? Are you sure you want to continue? Yes
⠹ Updating resources in the cloud. This may take a few minutes...Error updating cloudformation stack
✖ An error occurred when pushing the resources to the cloud

Template error: instance of Fn::GetAtt references undefined resource authamplifynexta0fb67a2
An error occurred during the push operation: Template error: instance of Fn::GetAtt references undefined resource authamplifynexta0fb67a2
```

</details>

This PR changes the README to use `storage` instead, which does push fine.